### PR TITLE
feat: deprecate tap in favor of doorcloud/door

### DIFF
--- a/Casks/doorctl.rb
+++ b/Casks/doorctl.rb
@@ -1,6 +1,8 @@
 cask "doorctl" do
   version "2.4.2"
 
+  deprecate! date: "2026-07-22", because: "moved to the doorcloud/door tap"
+
   on_arm do
     url "https://github.com/beopencloud/cno/releases/download/v#{version}/doorctl_Darwin_arm64.tar.gz"
     sha256 "b86911050b952e8b0df775469e79866f8d0cfd99e9dfd7b1da9a0dbfe45acfa2"

--- a/README.md
+++ b/README.md
@@ -1,5 +1,22 @@
 # CNO Homebrew repo
 
+> **Deprecation notice**
+>
+> This tap is deprecated. The official Door CLI distribution has moved to the [doorcloud/door](https://github.com/doorcloud/door) Homebrew tap.
+> Use the new command to install doorctl:
+> ```sh
+> brew install doorcloud/door/doorctl
+> ```
+>
+> Existing users can migrate with:
+> ```sh
+> brew uninstall doorctl
+> brew untap beopencloud/cno
+> brew install doorcloud/door/doorctl
+> ```
+>
+> Releases now track [doorcloud/door/releases](https://github.com/doorcloud/door/releases).
+
 Homebrew tap for Door CLI (`doorctl`).
 
 ## Requirements

--- a/doorctl.rb
+++ b/doorctl.rb
@@ -4,6 +4,8 @@ class Doorctl < Formula
   homepage "https://www.cloudoor.com/"
   license "Apache-2.0"
 
+  deprecate! date: "2026-07-22", because: "moved to the doorcloud/door tap"
+
   version "2.4.2"
 
   on_macos do


### PR DESCRIPTION
Deprecate the beopencloud/cno Homebrew tap.

- Add a deprecation banner to README.md with migration instructions.
- Add deprecate! to the doorctl formula and cask pointing users to the doorcloud/door tap.

No formulas are removed and the tap remains functional.

Made with [Cursor](https://cursor.com)